### PR TITLE
Always enable docker training when in evaluation mode

### DIFF
--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -34,6 +34,7 @@ class ObstacleTowerEnv(gym.Env):
         """
         if self.is_grading():
             environment_filename = None
+            docker_training = True
 
         self._env = UnityEnvironment(environment_filename, worker_id, docker_training=docker_training)
 


### PR DESCRIPTION
While participants to the OTC may or may not use "docker training"
mode, when we are evaluating we'll always be using a dockerized /
xvfb-required environment.  This change enables the docker_training
flag automatically in this case.