### PR TITLE
Correct typo in gcp_training.md

### DIFF
--- a/examples/gcp_training.md
+++ b/examples/gcp_training.md
@@ -97,8 +97,8 @@ Installing the obstacle tower environment will allow Obstacle Tower to act as an
 
 ```bash
 git clone https://github.com/Unity-Technologies/obstacle-tower-env
-pip3 install ./ 
 cd obstacle-tower-env
+pip3 install ./ 
 cd ../
 ```
 


### PR DESCRIPTION
Typo in bash commands for installing Obstacle Tower Environment.
First change dir, than do pip3 install.