### PR TITLE
Update to v2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ To learn more, please read our AAAI Workshop paper:
 * v2.1 Hotfix release.
    * Resolves issue with new seeds not being applied on `env.reset`.
    * Resolves issue with underspecified observation space.
+* v2.2 Hotfix release.
+   * Resolves issue with reset parameters sometimes not being updated during `env.reset`.
+   * Resolves issue where agents could possibly skip levels.
   
 
 ## Installation
@@ -56,11 +59,11 @@ Python dependencies (also in [setup.py](https://github.com/Unity-Technologies/ob
 
 | *Platform*     | *Download Link*                                                                     |
 | --- | --- |
-| Linux (x86_64) | https://storage.googleapis.com/obstacle-tower-build/v2.1/obstacletower_v2.1_linux.zip   |
-| Mac OS X       | https://storage.googleapis.com/obstacle-tower-build/v2.1/obstacletower_v2.1_osx.zip     |
-| Windows        | https://storage.googleapis.com/obstacle-tower-build/v2.1/obstacletower_v2.1_windows.zip |
+| Linux (x86_64) | https://storage.googleapis.com/obstacle-tower-build/v2.2/obstacletower_v2.2_linux.zip   |
+| Mac OS X       | https://storage.googleapis.com/obstacle-tower-build/v2.2/obstacletower_v2.2_osx.zip     |
+| Windows        | https://storage.googleapis.com/obstacle-tower-build/v2.2/obstacletower_v2.2_windows.zip |
 
-For checksums on these files, see [here](https://storage.googleapis.com/obstacle-tower-build/v2.1/ote-v2.1-checksums.txt).
+For checksums on these files, see [here](https://storage.googleapis.com/obstacle-tower-build/v2.2/ote-v2.2-checksums.txt).
 
 ### Install the Gym interface
 

--- a/examples/gcp_training.md
+++ b/examples/gcp_training.md
@@ -107,8 +107,8 @@ cd ../
 This page lists the URLs for downloading Obstacle Tower for various platforms. [https://github.com/Unity-Technologies/obstacle-tower-env](https://github.com/Unity-Technologies/obstacle-tower-env). For GCP, run
 
 ```bash
-wget https://storage.googleapis.com/obstacle-tower-build/v2.1/obstacletower_v2.1_linux.zip
-unzip obstacletower_v2.1_linux.zip
+wget https://storage.googleapis.com/obstacle-tower-build/v2.2/obstacletower_v2.2_linux.zip
+unzip obstacletower_v2.2_linux.zip
 ```
 
 ### Install Dopamine
@@ -157,7 +157,7 @@ cp dopamine_otc/unity_lib.py dopamine/dopamine/discrete_domains/unity_lib.py
 cp dopamine_otc/rainbow_otc.gin dopamine/dopamine/agents/rainbow/configs/rainbow_otc.gin
 ```
 
-If you didn’t extract the `obstacletower_v2.1_linux.zip` to the home directory, you will need to edit `rainbow_otc.gin`, specifically `create_otc_environment.environment_path` should correspond to the path to your extracted OTC executable file. 
+If you didn’t extract the `obstacletower_v2.2_linux.zip` to the home directory, you will need to edit `rainbow_otc.gin`, specifically `create_otc_environment.environment_path` should correspond to the path to your extracted OTC executable file. 
 
 Furthermore, within this file you will find settings on how long to train for, and how often to evaluate your agent. Each iteration, Dopamine will train for `Runner.training_steps`, evaluate (i.e. run in inference mode) for `Runner.evaluation_steps`, record these results, and checkpoint the agent. It will repeat this process `Runner.num_iterations` number of times before quitting. For instance, you can change `Runner.num_iterations` to 40 to train for 10 million steps. You can also reduce `Runner.evaluation_steps` to reduce the time spent not training. There are other hyperparameters found in this file, which you can modify to improve performance. But for the sake of this exercise, you may leave them as-is. 
 

--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("gym_unity")
 
 
 class ObstacleTowerEnv(gym.Env):
-    ALLOWED_VERSIONS = ['2.0', '2.1']
+    ALLOWED_VERSIONS = ['2.0', '2.1', '2.2']
 
     def __init__(self, environment_filename=None, docker_training=False, worker_id=0, retro=True,
                  timeout_wait=30, realtime_mode=False, config=None, greyscale=False):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='obstacle_tower_env',
-    version='2.1',
+    version='2.2',
     author='Unity Technologies',
     url='https://github.com/Unity-Technologies/obstacle-tower-env',
     py_modules=["obstacle_tower_env"],


### PR DESCRIPTION
* v2.2 Hotfix release.
   * Resolves issue with reset parameters sometimes not being updated during `env.reset`.
   * Resolves issue where agents could possibly skip levels.
