### PR TITLE
Add support for performance evaluation via a Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ It is also possible to launch the environment in "Player Mode," and directly con
 | L | Rotate camera right. |
 | Space | Character jump. |
 
+### Performance evaluation
+
+We provide an environment wrapper for evaluating performance of a player or agent across multiple pre-defined seeds.  We provide [an example implementation](examples/evaluation.py) of evaluation on a random policy.
+
 ### Training a Dopamine Rainbow agent on GCP
 
 If you are interested in training an agent using Google's Dopamine framework and/or Google Cloud Platform, see our guide [here](./examples/gcp_training.md).

--- a/examples/evaluation.py
+++ b/examples/evaluation.py
@@ -4,14 +4,17 @@ import argparse
 import time
 import multiprocessing
 
+
 def run_episode(env):
     done = False
-    reward = 0.0
+    episode_return = 0.0
     
     while not done:
         action = env.action_space.sample()
         obs, reward, done, info = env.step(action)
-    return reward
+        episode_return += reward
+    return episode_return
+
 
 if __name__ == '__main__':
     # In this example we use the seeds used for evaluating submissions 

--- a/examples/evaluation.py
+++ b/examples/evaluation.py
@@ -1,0 +1,38 @@
+from obstacle_tower_env import ObstacleTowerEnv, ObstacleTowerEvaluation
+import sys
+import argparse
+import time
+import multiprocessing
+
+def run_episode(env):
+    done = False
+    reward = 0.0
+    
+    while not done:
+        action = env.action_space.sample()
+        obs, reward, done, info = env.step(action)
+    return reward
+
+if __name__ == '__main__':
+    # In this example we use the seeds used for evaluating submissions 
+    # to the Obstacle Tower Challenge.
+    eval_seeds = [1001, 1002, 1003, 1004, 1005]
+
+    # Create the ObstacleTowerEnv gym and launch ObstacleTower
+    env = ObstacleTowerEnv('./ObstacleTower/obstacletower')
+
+    # Wrap the environment with the ObstacleTowerEvaluation wrapper
+    # and provide evaluation seeds.
+    env = ObstacleTowerEvaluation(env, eval_seeds)
+
+    # We can run episodes (in this case with a random policy) until 
+    # the "evaluation_complete" flag is True.  Attempting to step or reset after
+    # all of the evaluation seeds have completed will result in an exception.
+    while not env.evaluation_complete:
+        episode_rew = run_episode(env)
+
+    # Finally the evaluation results can be fetched as a dictionary from the 
+    # environment wrapper.
+    print(env.results)
+
+    env.close()

--- a/examples/evaluation.py
+++ b/examples/evaluation.py
@@ -1,8 +1,4 @@
 from obstacle_tower_env import ObstacleTowerEnv, ObstacleTowerEvaluation
-import sys
-import argparse
-import time
-import multiprocessing
 
 
 def run_episode(env):

--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -161,6 +161,7 @@ class ObstacleTowerEnv(gym.Env):
         if self._seed is not None:
             reset_params['tower-seed'] = self._seed
 
+        self.reset_params = self._env.reset_parameters
         info = self._env.reset(config=reset_params,
                                train_mode=not self.realtime_mode)[self.brain_name]
         n_agents = len(info.agents)
@@ -395,13 +396,14 @@ class ActionFlattener():
 
 
 class EpisodeResults:
-    def __init__(self, seed):
+    def __init__(self, seed, reset_params):
         self.seed = seed
         self.start_time = time.time()
         self.time_elapsed = None
         self.total_steps = 0
         self.reward = 0.0
         self.max_floor_reached = 0
+        self.reset_params = reset_params
 
     def complete(self, reward, floor, total_steps):
         curr_time = time.time()
@@ -416,7 +418,8 @@ class EpisodeResults:
             'time_elapsed': self.time_elapsed,
             'episode_reward': self.reward,
             'max_floor_reached': self.max_floor_reached,
-            'total_steps': self.total_steps
+            'total_steps': self.total_steps,
+            'reset_params': self.reset_params
         }
 
 
@@ -455,7 +458,10 @@ class ObstacleTowerEvaluation(gym.Wrapper):
         self.episodic_return = 0.0
         self.episodic_steps = 0
         self.current_floor = 0
-        self.episode_results[self.current_seed] = EpisodeResults(self.current_seed)
+        self.episode_results[self.current_seed] = EpisodeResults(
+            self.current_seed,
+            self.env.reset_params
+        )
         return obs
 
     def step(self, action):

--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -250,7 +250,7 @@ class ObstacleTowerEnv(gym.Env):
 
     def seed(self, seed=None):
         """Sets a fixed seed for this env's random number generator(s).
-        The valid range for seeds is [0, 100). By default a random seed
+        The valid range for seeds is [0, 99999). By default a random seed
         will be chosen.
         """
         if seed is None:
@@ -258,6 +258,11 @@ class ObstacleTowerEnv(gym.Env):
             return
 
         seed = int(seed)
+        if seed < 0 or seed >= 99999:
+            logger.warning(
+                "Seed outside of valid range [0, 99999). A random seed "
+                "within the valid range will be used on next reset."
+            )
         logger.warning("New seed " + str(seed) + " will apply on next reset.")
         self._seed = seed
 
@@ -269,9 +274,9 @@ class ObstacleTowerEnv(gym.Env):
             return
 
         floor = int(floor)
-        if floor < 0 or floor >= 99:
+        if floor < 0 or floor > 99:
             logger.warning(
-                "Starting floor outside of valid range [0, 99). Floor 0 will be used"
+                "Starting floor outside of valid range [0, 99]. Floor 0 will be used"
                 "on next reset."
             )
         logger.warning("New starting floor " + str(floor) + " will apply on next reset.")

--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -420,7 +420,7 @@ class ObstacleTowerEvaluation(gym.Wrapper):
     def __init__(self, env, seeds):
         """
         Arguments:
-        env: ObstacleTowerEnv for
+        env: ObstacleTowerEnv object created externally.
         """
         super().__init__(env)
 

--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -414,7 +414,7 @@ class EpisodeResults:
         return {
             'seed': self.seed,
             'time_elapsed': self.time_elapsed,
-            'reward': self.reward,
+            'episode_reward': self.reward,
             'max_floor_reached': self.max_floor_reached,
             'total_steps': self.total_steps
         }
@@ -441,6 +441,7 @@ class ObstacleTowerEvaluation(gym.Wrapper):
         self.episode_results = {}
         self.episodic_return = 0.0
         self.episodic_steps = 0
+        self.current_floor = 0
         self.seeds = deque(seeds)
         self.current_seed = self.seeds.popleft()
         self.env.seed(self.current_seed)
@@ -453,6 +454,7 @@ class ObstacleTowerEvaluation(gym.Wrapper):
         obs = self.env.reset()
         self.episodic_return = 0.0
         self.episodic_steps = 0
+        self.current_floor = 0
         self.episode_results[self.current_seed] = EpisodeResults(self.current_seed)
         return obs
 
@@ -463,10 +465,12 @@ class ObstacleTowerEvaluation(gym.Wrapper):
         observation, reward, done, info = self.env.step(action)
         self.episodic_return += reward
         self.episodic_steps += 1
+        if info['current_floor'] > self.current_floor:
+            self.current_floor = info['current_floor']
         if done:
             self.episode_results[self.current_seed].complete(
                 self.episodic_return,
-                info['current_floor'],
+                self.current_floor,
                 self.episodic_steps)
             if len(self.seeds) > 0:
                 self.current_seed = self.seeds.popleft()

--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -1,4 +1,7 @@
 import logging
+import time
+from collections import deque
+
 from PIL import Image
 import itertools
 import gym
@@ -6,7 +9,6 @@ import numpy as np
 import time
 from collections import deque
 from gym import error, spaces
-import os
 from mlagents.envs import UnityEnvironment
 
 


### PR DESCRIPTION
This change adds a gym wrapper for collecting max rewards and max floors
across a set of seeds provided by the user.  Includes an update to the
README and an example of usage which mimics OTC evaluation.