### PR TITLE
fixed _check_agents() 

### DIFF
--- a/obstacle_tower_env.py
+++ b/obstacle_tower_env.py
@@ -97,7 +97,6 @@ class ObstacleTowerEnv(gym.Env):
             )
 
         self.visual_obs = None
-        self._current_state = None
         self._n_agents = None
         self._flattener = None
         self._greyscale = greyscale
@@ -229,13 +228,16 @@ class ObstacleTowerEnv(gym.Env):
 
         self._env.set_actions(self.behavior_name, action.reshape([1, -1]))
         self._env.step()
-        info, terminal_info = self._env.get_steps(self.behavior_name)
-        n_agents = len(info)
-        self._check_agents(n_agents)
-        self._current_state = info
-
-        obs, reward, done, info = self._single_step(info, terminal_info)
+        running_info, terminal_info = self._env.get_steps(self.behavior_name)
+        obs, reward, done, info = self._single_step(running_info, terminal_info)
         self.game_over = done
+
+        # Verify that not more than one agent is present inside the environment
+        if done:
+            n_agents = len(terminal_info)
+        else:
+            n_agents = len(running_info)
+        self._check_agents(n_agents)
 
         return obs, reward, done, info
 


### PR DESCRIPTION
This fixes issue #120 and I removed the variable self._current_state, because it does not have any use.

While this is the solution to issue #120, I think this check can be omitted inside of step(), because how likely is it that someone uses an Obstacle Tower build that eventually spawns additional agents in the middle of an episode?